### PR TITLE
Left assoc in left right recursion

### DIFF
--- a/tatsu/contexts.py
+++ b/tatsu/contexts.py
@@ -476,6 +476,9 @@ class ParseContext(object):
     def _set_recursive(self, name):
         self._recursive_rules.add(name)
 
+    def _unset_recursive(self, name):
+        self._recursive_rules.remove(name)
+
     def _set_left_recursion_guard(self, key):
         ex = self._make_exception(key.name, exclass=FailedLeftRecursion)
         self._memoize(key, ex)

--- a/test/grammar/left_recursion_test.py
+++ b/test/grammar/left_recursion_test.py
@@ -203,7 +203,7 @@ class LeftRecursionTests(unittest.TestCase):
         model.parse('3 - 2 - 1', trace=trace, colorize=True)
         model.parse('3 - (2 - 1)', trace=trace, colorize=True)
 
-    def _no_test_left_and_right_recursion(self, trace=True):
+    def test_left_and_right_recursion(self, trace=False):
         # by Nicolas LAURENT in eg@lists.csail.mit.edu
         grammar = '''
             @@left_recursion :: True

--- a/test/grammar/left_recursion_test.py
+++ b/test/grammar/left_recursion_test.py
@@ -203,7 +203,7 @@ class LeftRecursionTests(unittest.TestCase):
         model.parse('3 - 2 - 1', trace=trace, colorize=True)
         model.parse('3 - (2 - 1)', trace=trace, colorize=True)
 
-    def test_left_and_right_recursion(self, trace=False):
+    def test_left_recursion_with_right_associativity(self, trace=False):
         # by Nicolas LAURENT in eg@lists.csail.mit.edu
         grammar = '''
             @@left_recursion :: True
@@ -214,4 +214,4 @@ class LeftRecursionTests(unittest.TestCase):
         '''
         model = compile(grammar, "test")
         ast = model.parse("1+2+3", trace=trace, colorize=True)
-        self.assertEqual([['1', '+', '2'], '+', '3'], ast)
+        self.assertEqual(['1', '+', ['2', '+', '3']], ast)


### PR DESCRIPTION
Only the unit test. Allow right-associativity in lef+right recursion.